### PR TITLE
Use a less strict check in chatgpt response

### DIFF
--- a/privet/ailabs/controller/chatgpt.php
+++ b/privet/ailabs/controller/chatgpt.php
@@ -241,7 +241,7 @@ class chatgpt extends AIController
             if (
                 empty($json->object) ||
                 empty($json->choices) ||
-                $json->object != 'chat.completion' ||
+                strpos($json->object, 'chat.completion') === false ||
                 !in_array(200, $api->responseCodes)
             ) {
             } else {


### PR DESCRIPTION
Hi, there is a mismatch when `response->object` is `chat.completion.chunk`, this pr solve this problem.

Here is the corresponding log
```json
{
  "start": "2024-01-11 07:21:15",
  "history.pattern": "/<QUOTE\\sauthor=\"chatgpt\"\\spost_id=\"(.*)\"\\stime=\"(.*)\"\\suser_id=\"108\">/",
  "request.messages": [
    {
      "role": "user",
      "content": "[smention u=108]chatgpt[/smention] 你好"
    }
  ],
  "response": {
    "object": "chat.completion.chunk",
    "model": "gpt-4",
    "choices": [
      {
        "content_filter_results": {
          "hate": {
            "filtered": false,
            "severity": "safe"
          },
          "self_harm": {
            "filtered": false,
            "severity": "safe"
          },
          "sexual": {
            "filtered": false,
            "severity": "safe"
          },
          "violence": {
            "filtered": false,
            "severity": "safe"
          }
        },
        "finish_reason": "stop",
        "index": 0,
        "message": {
          "content": "你好，有什么我可以帮助你的吗？",
          "role": "assistant"
        }
      }
    ],
    "created": 1704957676,
    "id": "chatcmpl-8fjfI57MekHIXn7pZJveEOumr2VId",
    "prompt_filter_results": [
      {
        "content_filter_results": {
          "hate": {
            "filtered": false,
            "severity": "safe"
          },
          "self_harm": {
            "filtered": false,
            "severity": "safe"
          },
          "sexual": {
            "filtered": false,
            "severity": "safe"
          },
          "violence": {
            "filtered": false,
            "severity": "safe"
          }
        },
        "prompt_index": 0
      }
    ],
    "usage": {
      "completion_tokens": 18,
      "prompt_tokens": 23,
      "total_tokens": 41
    }
  },
  "response.codes": [
    200
  ],
  "finish": "2024-01-11 07:21:17"
}
```